### PR TITLE
Fix bug where valid on/1 options were considered invalid

### DIFF
--- a/src/chaos_monkey.erl
+++ b/src/chaos_monkey.erl
@@ -224,7 +224,7 @@ verify_opts(Opts) ->
                         case Apps =:= all
                             orelse Apps =:= all_but_otp
                             orelse lists:all(fun(X) -> is_atom(X) end, Apps) of
-                            true ->
+                            true when is_list(Apps) ->
                                 AllApps = application:loaded_applications(),
                                 case lists:all(
                                        fun(X) ->
@@ -235,6 +235,8 @@ verify_opts(Opts) ->
                                     false ->
                                         {error, unknown_application}
                                 end;
+                            true ->
+                                {ok, Ms, Apps};
                             false ->
                                 {error, badly_formed_apps}
                         end;


### PR DESCRIPTION
The following options for chaos_monkey:on/1 caused {error, badarg} to be
returned:
- {apps, all}
- {apps, all_but_otp}
