### PR TITLE
Add is_system_process and remove pman dependency.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,11 +9,10 @@ or
 It also works cleanly if you include it as a dependency in rebar.
 
 To test, find yourself a project, include the path to the code, run
-application:start(pman), application:start(chaos_monkey), and then run
-chaos_monkey:on() or chaos_monkey:kill(), to kill processes over time
-or kill a single process respectively.  You can also test the
-stability of a single application with
-chaos_monkey:almost_kill([AppName]).
+application:start(chaos_monkey), and then run chaos_monkey:on() or
+chaos_monkey:kill(), to kill processes over time or kill a single
+process respectively.  You can also test the stability of a single
+application with chaos_monkey:almost_kill([AppName]).
 
 I've personally been using cowboy_examples for testing.  Just because
 installation was so extremely quick.  If your current working

--- a/src/chaos_monkey.app.src
+++ b/src/chaos_monkey.app.src
@@ -8,8 +8,7 @@
   {registered, [chaos_monkey]},
   {applications,
    [kernel,
-    stdlib,
-    pman]},
+    stdlib]},
   {mod, {chaos_monkey_app, []}},
   {env, []}
  ]


### PR DESCRIPTION
OTP 17.0 removed `pman_process:is_system_process/1` used to detect system processes, I've copied this function from an old version allowing to chaos_monkey to stop depending on pman.
